### PR TITLE
Reapply "Allow spoofing signingInfo for microG Companion/Services"

### DIFF
--- a/services/core/java/com/android/server/pm/ComputerEngine.java
+++ b/services/core/java/com/android/server/pm/ComputerEngine.java
@@ -167,6 +167,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1562,6 +1563,21 @@ public class ComputerEngine implements Computer {
 
             if (packageInfo == null) {
                 return null;
+            }
+
+            if (isMicroG) {
+                try {
+                    packageInfo.signingInfo = new SigningInfo(
+                            new SigningDetails(
+                                    packageInfo.signatures,
+                                    SigningDetails.SignatureSchemeVersion.SIGNING_BLOCK_V3,
+                                    SigningDetails.toSigningKeys(packageInfo.signatures),
+                                    null
+                            )
+                    );
+                } catch (CertificateException e) {
+                    Slog.e(TAG, "Caught an exception when creating signing keys: ", e);
+                }
             }
 
             packageInfo.packageName = packageInfo.applicationInfo.packageName =


### PR DESCRIPTION
Fixes Signature Spoofing in AOSP Extended

Original-Change-Id: I86f182c9e1d18b0e997803842577a90ef740cfd1
Change-Id: Ie480255ed3bd80809803698752cafb3a2ecc3a33